### PR TITLE
Implement minimal online judge MVP

### DIFF
--- a/online-judge-mvp/.env.example
+++ b/online-judge-mvp/.env.example
@@ -1,0 +1,4 @@
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@postgres:5432/postgres
+REDIS_URL=redis://redis:6379/0
+JUDGE0_URL=http://judge0:2358
+NEXT_PUBLIC_BACKEND_URL=http://localhost:8000

--- a/online-judge-mvp/backend/Dockerfile
+++ b/online-judge-mvp/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app ./app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/online-judge-mvp/backend/app/database.py
+++ b/online-judge-mvp/backend/app/database.py
@@ -1,0 +1,19 @@
+import os
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+
+engine = create_async_engine(DATABASE_URL, echo=False, future=True)
+
+Base = declarative_base()
+
+async_session = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+async def init_models() -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+async def get_session() -> AsyncSession:
+    async with async_session() as session:
+        yield session

--- a/online-judge-mvp/backend/app/main.py
+++ b/online-judge-mvp/backend/app/main.py
@@ -1,0 +1,49 @@
+import os
+from fastapi import FastAPI, Depends, HTTPException
+from fastapi.responses import JSONResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from redis.asyncio import Redis
+
+from .database import get_session, init_models
+from .models import Problem, Submission
+from .schemas import ProblemOut, SubmissionCreate, SubmissionOut
+
+app = FastAPI()
+redis = Redis.from_url(os.getenv("REDIS_URL"))
+
+@app.on_event("startup")
+async def startup() -> None:
+    await init_models()
+
+@app.get("/problems", response_model=list[ProblemOut])
+async def list_problems(session: AsyncSession = Depends(get_session)):
+    result = await session.execute(select(Problem))
+    return result.scalars().all()
+
+@app.get("/problems/{problem_id}", response_model=ProblemOut)
+async def get_problem(problem_id: int, session: AsyncSession = Depends(get_session)):
+    problem = await session.get(Problem, problem_id)
+    if not problem:
+        raise HTTPException(status_code=404, detail="Problem not found")
+    return problem
+
+@app.post("/submit", response_model=SubmissionOut, status_code=201)
+async def submit(data: SubmissionCreate, session: AsyncSession = Depends(get_session)):
+    sub = Submission(problem_id=data.problem_id, code=data.code, stdin=data.stdin)
+    session.add(sub)
+    await session.commit()
+    await session.refresh(sub)
+    await redis.rpush("queue:sub", sub.id)
+    return sub
+
+@app.get("/submissions/{submission_id}", response_model=SubmissionOut)
+async def get_submission(submission_id: int, session: AsyncSession = Depends(get_session)):
+    sub = await session.get(Submission, submission_id)
+    if not sub:
+        raise HTTPException(status_code=404, detail="Submission not found")
+    return sub
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(_, exc: HTTPException):
+    return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})

--- a/online-judge-mvp/backend/app/models.py
+++ b/online-judge-mvp/backend/app/models.py
@@ -1,0 +1,39 @@
+from sqlalchemy import Column, Integer, String, Text, ForeignKey, Float, DateTime
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from .database import Base
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True)
+    username = Column(String(50), unique=True, nullable=False)
+
+    submissions = relationship("Submission", back_populates="user")
+
+class Problem(Base):
+    __tablename__ = "problems"
+
+    id = Column(Integer, primary_key=True)
+    title = Column(String(100), nullable=False)
+    description = Column(Text, nullable=False)
+
+    submissions = relationship("Submission", back_populates="problem")
+
+class Submission(Base):
+    __tablename__ = "submissions"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    problem_id = Column(Integer, ForeignKey("problems.id"), nullable=False)
+    code = Column(Text, nullable=False)
+    stdin = Column(Text)
+    stdout = Column(Text)
+    stderr = Column(Text)
+    status = Column(String(50), default="Queued", nullable=False)
+    time = Column(Float)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    user = relationship("User", back_populates="submissions")
+    problem = relationship("Problem", back_populates="submissions")

--- a/online-judge-mvp/backend/app/schemas.py
+++ b/online-judge-mvp/backend/app/schemas.py
@@ -1,0 +1,26 @@
+from typing import Optional
+from pydantic import BaseModel
+
+class ProblemOut(BaseModel):
+    id: int
+    title: str
+    description: str
+
+    class Config:
+        from_attributes = True
+
+class SubmissionCreate(BaseModel):
+    problem_id: int
+    code: str
+    stdin: Optional[str] = ""
+
+class SubmissionOut(BaseModel):
+    id: int
+    problem_id: int
+    stdout: Optional[str] = None
+    stderr: Optional[str] = None
+    status: str
+    time: Optional[float] = None
+
+    class Config:
+        from_attributes = True

--- a/online-judge-mvp/backend/app/worker.py
+++ b/online-judge-mvp/backend/app/worker.py
@@ -1,0 +1,57 @@
+import os
+import asyncio
+import httpx
+from redis.asyncio import Redis
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from .models import Submission
+from .database import Base
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+JUDGE0_URL = os.getenv("JUDGE0_URL")
+REDIS_URL = os.getenv("REDIS_URL")
+
+engine = create_async_engine(DATABASE_URL, future=True)
+SessionLocal = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+redis = Redis.from_url(REDIS_URL)
+
+async def process_submission(sub_id: int) -> None:
+    async with SessionLocal() as session:
+        submission = await session.get(Submission, sub_id)
+        if not submission:
+            return
+        payload = {
+            "language_id": 71,
+            "source_code": submission.code,
+            "stdin": submission.stdin or "",
+        }
+        async with httpx.AsyncClient() as client:
+            res = await client.post(f"{JUDGE0_URL}/submissions/?base64_encoded=false", json=payload)
+            token = res.json()["token"]
+            result = {"status": {"id": 1}}
+            while result["status"]["id"] in (1, 2):
+                await asyncio.sleep(1)
+                r = await client.get(f"{JUDGE0_URL}/submissions/{token}?base64_encoded=false")
+                result = r.json()
+        submission.stdout = result.get("stdout")
+        submission.stderr = result.get("stderr")
+        submission.status = result["status"]["description"]
+        submission.time = result.get("time")
+        await session.commit()
+
+async def worker() -> None:
+    while True:
+        _, raw_id = await redis.blpop("queue:sub")
+        sub_id = int(raw_id)
+        try:
+            await process_submission(sub_id)
+        except Exception:
+            async with SessionLocal() as session:
+                sub = await session.get(Submission, sub_id)
+                if sub:
+                    sub.status = "Internal Error"
+                    await session.commit()
+
+if __name__ == "__main__":
+    asyncio.run(worker())

--- a/online-judge-mvp/backend/requirements.txt
+++ b/online-judge-mvp/backend/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+SQLAlchemy>=2
+asyncpg
+redis
+httpx
+pydantic>=2

--- a/online-judge-mvp/docker-compose.yml
+++ b/online-judge-mvp/docker-compose.yml
@@ -1,0 +1,51 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - '5432:5432'
+
+  redis:
+    image: redis:7
+    restart: always
+    ports:
+      - '6379:6379'
+
+  judge0:
+    image: judge0/judge0:1.13.0
+    restart: always
+    env_file: .env
+    ports:
+      - '2358:2358'
+
+  backend:
+    build: ./backend
+    env_file: .env
+    depends_on:
+      - postgres
+      - redis
+      - judge0
+    ports:
+      - '8000:8000'
+
+  worker:
+    build: ./backend
+    command: ['python', 'app/worker.py']
+    env_file: .env
+    depends_on:
+      - backend
+      - postgres
+      - redis
+      - judge0
+
+  frontend:
+    build: ./frontend
+    env_file: .env
+    depends_on:
+      - backend
+    ports:
+      - '3000:3000'

--- a/online-judge-mvp/frontend/Dockerfile
+++ b/online-judge-mvp/frontend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18-alpine AS builder
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+RUN npm run build
+EXPOSE 3000
+CMD ["npm", "run", "start"]

--- a/online-judge-mvp/frontend/src/app/problems/[id]/page.tsx
+++ b/online-judge-mvp/frontend/src/app/problems/[id]/page.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Editor from '@monaco-editor/react'
+
+interface Problem {
+  id: number
+  title: string
+  description: string
+}
+
+interface Submission {
+  id: number
+  stdout?: string
+  stderr?: string
+  status: string
+  time?: number
+}
+
+export default function ProblemPage({ params }: { params: { id: string } }) {
+  const [problem, setProblem] = useState<Problem | null>(null)
+  const [code, setCode] = useState('')
+  const [stdin, setStdin] = useState('')
+  const [sub, setSub] = useState<Submission | null>(null)
+  const API = process.env.NEXT_PUBLIC_BACKEND_URL
+
+  useEffect(() => {
+    fetch(`${API}/problems/${params.id}`)
+      .then(res => res.json())
+      .then(setProblem)
+  }, [params.id])
+
+  const submit = async () => {
+    const res = await fetch(`${API}/submit`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ problem_id: Number(params.id), code, stdin })
+    })
+    const data = await res.json()
+    setSub(data)
+    if (res.ok) poll(data.id)
+  }
+
+  const poll = async (id: number) => {
+    let result: Submission
+    do {
+      await new Promise(r => setTimeout(r, 1000))
+      const res = await fetch(`${API}/submissions/${id}`)
+      result = await res.json()
+      setSub(result)
+    } while (result.status === 'Queued' || result.status === 'Processing')
+  }
+
+  return (
+    <div className='p-4'>
+      <h1 className='text-2xl font-bold'>{problem?.title}</h1>
+      <p className='whitespace-pre-wrap'>{problem?.description}</p>
+      <div className='my-4'>
+        <Editor height='40vh' defaultLanguage='python' value={code} onChange={(v) => setCode(v || '')} />
+      </div>
+      <textarea className='w-full border p-2' rows={5} placeholder='stdin' value={stdin} onChange={e => setStdin(e.target.value)} />
+      <button className='mt-2 px-4 py-2 bg-blue-500 text-white' onClick={submit}>Run</button>
+      {sub && (
+        <table className='mt-4 table-auto border'>
+          <tbody>
+            <tr><th>Status</th><td>{sub.status}</td></tr>
+            <tr><th>Time</th><td>{sub.time}</td></tr>
+            <tr><th>stdout</th><td><pre>{sub.stdout}</pre></td></tr>
+            <tr><th>stderr</th><td><pre>{sub.stderr}</pre></td></tr>
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add docker-compose with backend, worker, frontend, postgres, redis, judge0
- implement FastAPI backend with async SQLAlchemy models and routes
- provide worker to interface with Judge0
- add Next.js problem page with Monaco editor
- document environment variables for local setup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a39945bfc83289ce2a8dfa403ef5d