### PR TITLE
Switch to local setup without Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
 # kmc_KosenProcon_TTS
+
+This repository contains a minimal online judge prototype.
+
+## Getting Started (without Docker)
+
+1. **Create a Python virtual environment**
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r online-judge-mvp/backend/requirements.txt
+   ```
+
+2. **Install Node.js 20 and pnpm**, then install frontend dependencies:
+
+   ```bash
+   cd online-judge-mvp/frontend
+   pnpm install
+   ```
+
+3. **Configure environment variables**
+
+   ```bash
+   cp online-judge-mvp/.env.example online-judge-mvp/.env
+   ```
+   The default settings use SQLite and access the public Judge0 API.
+
+4. **Run the backend and worker** (in separate terminals):
+
+   ```bash
+   cd online-judge-mvp/backend
+   uvicorn app.main:app --reload
+   # another terminal
+   python app/worker.py
+   ```
+
+5. **Run the frontend**
+
+   ```bash
+   cd online-judge-mvp/frontend
+   pnpm dev
+   ```
+
+Open <http://localhost:3000> in your browser to access the application.
+
+This setup avoids Docker and relies on SQLite, reducing disk usage by several gigabytes compared to the container-based version.
+

--- a/online-judge-mvp/.env.example
+++ b/online-judge-mvp/.env.example
@@ -1,4 +1,4 @@
-DATABASE_URL=postgresql+asyncpg://postgres:postgres@postgres:5432/postgres
-REDIS_URL=redis://redis:6379/0
-JUDGE0_URL=http://judge0:2358
+DATABASE_URL=sqlite+aiosqlite:///./database.db
+REDIS_URL=redis://localhost:6379/0
+JUDGE0_URL=https://ce.judge0.com
 NEXT_PUBLIC_BACKEND_URL=http://localhost:8000

--- a/online-judge-mvp/backend/requirements.txt
+++ b/online-judge-mvp/backend/requirements.txt
@@ -1,7 +1,7 @@
 fastapi
 uvicorn
 SQLAlchemy>=2
-asyncpg
+aiosqlite
 redis
 httpx
 pydantic>=2


### PR DESCRIPTION
## Summary
- document running the app without Docker
- provide SQLite configuration in `.env.example`
- remove `asyncpg` dependency in favour of `aiosqlite`

## Testing
- `pip install -r online-judge-mvp/backend/requirements.txt`
- `python -m compileall online-judge-mvp/backend/app`

------
https://chatgpt.com/codex/tasks/task_e_684ff5c717d08328a58e1e61952bdc89