### PR TITLE
Add PaaS online judge scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,29 @@
-# kmc_KosenProcon_TTS
+# Online Judge MVP
 
-This repository contains a minimal online judge prototype.
+This project provides a minimal online judge using FastAPI, Supabase Postgres, Render and Vercel.
 
-## Getting Started (without Docker)
+## Setup Overview
 
-1. **Create a Python virtual environment**
+1. **Create a Supabase project** and note the Postgres connection string. Enable public network access.
+2. **Import this repository to Render** and deploy `online-judge-mvp/backend` as a Web Service. Set the following environment variables:
+   - `DATABASE_URL` – Supabase connection string
+   - `JUDGE0_URL` – `https://ce.judge0.com`
+3. **Import `online-judge-mvp/frontend` to Vercel** and set `NEXT_PUBLIC_API_URL` to the Render service URL.
 
-   ```bash
-   python -m venv .venv
-   source .venv/bin/activate
-   pip install -r online-judge-mvp/backend/requirements.txt
-   ```
+Supabase requires no additional schema; tables are created automatically on first launch.
 
-2. **Install Node.js 20 and pnpm**, then install frontend dependencies:
+## Local Development
 
-   ```bash
-   cd online-judge-mvp/frontend
-   pnpm install
-   ```
+```bash
+# Backend
+cd online-judge-mvp/backend
+pip install -r requirements.txt
+uvicorn app.main:app --reload
 
-3. **Configure environment variables**
+# Frontend
+cd ../frontend
+pnpm install
+pnpm dev
+```
 
-   ```bash
-   cp online-judge-mvp/.env.example online-judge-mvp/.env
-   ```
-   The default settings use SQLite and access the public Judge0 API.
-
-4. **Run the backend and worker** (in separate terminals):
-
-   ```bash
-   cd online-judge-mvp/backend
-   uvicorn app.main:app --reload
-   # another terminal
-   python app/worker.py
-   ```
-
-5. **Run the frontend**
-
-   ```bash
-   cd online-judge-mvp/frontend
-   pnpm dev
-   ```
-
-Open <http://localhost:3000> in your browser to access the application.
-
-This setup avoids Docker and relies on SQLite, reducing disk usage by several gigabytes compared to the container-based version.
-
+Open `http://localhost:3000` to access the app.

--- a/online-judge-mvp/backend/app/judge0.py
+++ b/online-judge-mvp/backend/app/judge0.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import os
+import httpx
+
+JUDGE0_URL = os.getenv("JUDGE0_URL", "https://ce.judge0.com")
+
+async def run_code(code: str, stdin: str) -> dict:
+    payload = {
+        "language_id": 71,  # Python 3
+        "source_code": code,
+        "stdin": stdin,
+    }
+    async with httpx.AsyncClient() as client:
+        res = await client.post(
+            f"{JUDGE0_URL}/submissions/?base64_encoded=false&wait=true",
+            json=payload,
+        )
+        data = res.json()
+    return {
+        "stdout": data.get("stdout"),
+        "stderr": data.get("stderr"),
+        "status": data["status"]["description"],
+        "time": data.get("time"),
+    }

--- a/online-judge-mvp/backend/app/main.py
+++ b/online-judge-mvp/backend/app/main.py
@@ -1,45 +1,77 @@
-import os
-from fastapi import FastAPI, Depends, HTTPException
-from fastapi.responses import JSONResponse
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.future import select
-from redis.asyncio import Redis
+from __future__ import annotations
 
-from .database import get_session, init_models
-from .models import Problem, Submission
-from .schemas import ProblemOut, SubmissionCreate, SubmissionOut
+from fastapi import FastAPI, HTTPException, Depends, BackgroundTasks
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from sqlmodel import SQLModel, Session, select
+
+from .models import Problem, Submission, get_engine
+from .schemas import ProblemRead, SubmissionCreate, SubmissionRead
+from .judge0 import run_code
 
 app = FastAPI()
-redis = Redis.from_url(os.getenv("REDIS_URL"))
+
+origins = ["http://localhost:3000", "https://*.vercel.app"]
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+def get_session() -> Session:
+    engine = get_engine()
+    with Session(engine) as session:
+        yield session
 
 @app.on_event("startup")
-async def startup() -> None:
-    await init_models()
+def on_startup() -> None:
+    engine = get_engine()
+    SQLModel.metadata.create_all(engine)
 
-@app.get("/problems", response_model=list[ProblemOut])
-async def list_problems(session: AsyncSession = Depends(get_session)):
-    result = await session.execute(select(Problem))
-    return result.scalars().all()
+@app.get("/problems", response_model=list[ProblemRead])
+async def list_problems(session: Session = Depends(get_session)):
+    problems = session.exec(select(Problem)).all()
+    return problems
 
-@app.get("/problems/{problem_id}", response_model=ProblemOut)
-async def get_problem(problem_id: int, session: AsyncSession = Depends(get_session)):
-    problem = await session.get(Problem, problem_id)
+@app.get("/problems/{problem_id}", response_model=ProblemRead)
+async def get_problem(problem_id: int, session: Session = Depends(get_session)):
+    problem = session.get(Problem, problem_id)
     if not problem:
         raise HTTPException(status_code=404, detail="Problem not found")
     return problem
 
-@app.post("/submit", response_model=SubmissionOut, status_code=201)
-async def submit(data: SubmissionCreate, session: AsyncSession = Depends(get_session)):
+@app.post("/submit", response_model=SubmissionRead, status_code=201)
+async def submit(
+    data: SubmissionCreate,
+    background: BackgroundTasks,
+    session: Session = Depends(get_session),
+):
     sub = Submission(problem_id=data.problem_id, code=data.code, stdin=data.stdin)
     session.add(sub)
-    await session.commit()
-    await session.refresh(sub)
-    await redis.rpush("queue:sub", sub.id)
+    session.commit()
+    session.refresh(sub)
+    background.add_task(process_submission, sub.id)
     return sub
 
-@app.get("/submissions/{submission_id}", response_model=SubmissionOut)
-async def get_submission(submission_id: int, session: AsyncSession = Depends(get_session)):
-    sub = await session.get(Submission, submission_id)
+async def process_submission(submission_id: int) -> None:
+    engine = get_engine()
+    with Session(engine) as session:
+        sub = session.get(Submission, submission_id)
+        if not sub:
+            return
+        result = await run_code(sub.code, sub.stdin or "")
+        sub.stdout = result.get("stdout")
+        sub.stderr = result.get("stderr")
+        sub.status = result.get("status")
+        sub.time = result.get("time")
+        session.add(sub)
+        session.commit()
+
+@app.get("/submissions/{submission_id}", response_model=SubmissionRead)
+async def get_submission(submission_id: int, session: Session = Depends(get_session)):
+    sub = session.get(Submission, submission_id)
     if not sub:
         raise HTTPException(status_code=404, detail="Submission not found")
     return sub

--- a/online-judge-mvp/backend/app/schemas.py
+++ b/online-judge-mvp/backend/app/schemas.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
 from typing import Optional
 from pydantic import BaseModel
 
-class ProblemOut(BaseModel):
+class ProblemRead(BaseModel):
     id: int
     title: str
     description: str
+    sample_input: Optional[str] = None
+    sample_output: Optional[str] = None
 
     class Config:
         from_attributes = True
@@ -14,12 +18,12 @@ class SubmissionCreate(BaseModel):
     code: str
     stdin: Optional[str] = ""
 
-class SubmissionOut(BaseModel):
+class SubmissionRead(BaseModel):
     id: int
     problem_id: int
+    status: str
     stdout: Optional[str] = None
     stderr: Optional[str] = None
-    status: str
     time: Optional[float] = None
 
     class Config:

--- a/online-judge-mvp/backend/render.yaml
+++ b/online-judge-mvp/backend/render.yaml
@@ -1,0 +1,13 @@
+services:
+- type: web
+  name: oj-backend
+  env: python
+  plan: free
+  buildCommand: "pip install -r requirements.txt"
+  startCommand: "uvicorn app.main:app --host 0.0.0.0 --port $PORT"
+  autoDeploy: true
+  envVars:
+    - key: DATABASE_URL
+      sync: false
+    - key: JUDGE0_URL
+      value: https://ce.judge0.com

--- a/online-judge-mvp/backend/requirements.txt
+++ b/online-judge-mvp/backend/requirements.txt
@@ -1,7 +1,7 @@
-fastapi
+fastapi==0.111.0
 uvicorn
-SQLAlchemy>=2
-aiosqlite
-redis
+SQLModel
+asyncpg
+python-dotenv
 httpx
-pydantic>=2
+python-multipart

--- a/online-judge-mvp/frontend/next.config.js
+++ b/online-judge-mvp/frontend/next.config.js
@@ -1,0 +1,11 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true,
+  },
+  env: {
+    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
+  },
+}
+module.exports = nextConfig

--- a/online-judge-mvp/frontend/package.json
+++ b/online-judge-mvp/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "oj-frontend",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@monaco-editor/react": "^4.4.6"
+  },
+  "devDependencies": {
+    "typescript": "5.3.3",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.21",
+    "autoprefixer": "^10.4.13"
+  }
+}

--- a/online-judge-mvp/frontend/src/app/problems/[id]/page.tsx
+++ b/online-judge-mvp/frontend/src/app/problems/[id]/page.tsx
@@ -7,6 +7,8 @@ interface Problem {
   id: number
   title: string
   description: string
+  sample_input?: string
+  sample_output?: string
 }
 
 interface Submission {
@@ -22,13 +24,13 @@ export default function ProblemPage({ params }: { params: { id: string } }) {
   const [code, setCode] = useState('')
   const [stdin, setStdin] = useState('')
   const [sub, setSub] = useState<Submission | null>(null)
-  const API = process.env.NEXT_PUBLIC_BACKEND_URL
+  const API = process.env.NEXT_PUBLIC_API_URL
 
   useEffect(() => {
     fetch(`${API}/problems/${params.id}`)
       .then(res => res.json())
       .then(setProblem)
-  }, [params.id])
+  }, [params.id, API])
 
   const submit = async () => {
     const res = await fetch(`${API}/submit`, {
@@ -36,7 +38,7 @@ export default function ProblemPage({ params }: { params: { id: string } }) {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ problem_id: Number(params.id), code, stdin })
     })
-    const data = await res.json()
+    const data: Submission = await res.json()
     setSub(data)
     if (res.ok) poll(data.id)
   }
@@ -63,10 +65,10 @@ export default function ProblemPage({ params }: { params: { id: string } }) {
       {sub && (
         <table className='mt-4 table-auto border'>
           <tbody>
-            <tr><th>Status</th><td>{sub.status}</td></tr>
-            <tr><th>Time</th><td>{sub.time}</td></tr>
-            <tr><th>stdout</th><td><pre>{sub.stdout}</pre></td></tr>
-            <tr><th>stderr</th><td><pre>{sub.stderr}</pre></td></tr>
+            <tr><th className='px-2 text-left'>Status</th><td>{sub.status}</td></tr>
+            <tr><th className='px-2 text-left'>Time</th><td>{sub.time}</td></tr>
+            <tr><th className='px-2 text-left'>stdout</th><td><pre>{sub.stdout}</pre></td></tr>
+            <tr><th className='px-2 text-left'>stderr</th><td><pre>{sub.stderr}</pre></td></tr>
           </tbody>
         </table>
       )}

--- a/online-judge-mvp/frontend/tailwind.config.ts
+++ b/online-judge-mvp/frontend/tailwind.config.ts
@@ -1,0 +1,10 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+export default config


### PR DESCRIPTION
## Summary
- rewrite backend to use SQLModel, CORS, and Judge0 API
- add Render deploy config
- add Next.js and Tailwind configs for frontend
- implement problem page with polling
- provide minimal README for Supabase, Render, and Vercel deployment

## Testing
- `python -m py_compile online-judge-mvp/backend/app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684ff99144288328bf4301e2b40eb18b